### PR TITLE
Updates: Teams.teams_info()

### DIFF
--- a/nhlpy/_version.py
+++ b/nhlpy/_version.py
@@ -1,3 +1,3 @@
 # Should this be driven by the main pyproject.toml file? yes, is it super convoluted? yes, can it wait? sure
 
-__version__ = "2.9.2"
+__version__ = "2.10.0"

--- a/nhlpy/api/teams.py
+++ b/nhlpy/api/teams.py
@@ -1,5 +1,3 @@
-import json
-import importlib.resources
 from typing import List
 
 from nhlpy.http_client import HttpClient
@@ -11,18 +9,41 @@ class Teams:
         self.base_url = "https://api.nhle.com"
         self.api_ver = "/stats/rest/"
 
-    def teams_info(self) -> dict:
+    def teams_info(self, date: str = "now") -> List[dict]:
         """
-        Returns a list of dicts with all the teams info.  This is loaded via a harccoded json file.
+
+        :param date: Optional string, in format YYYY-MM-DD.  Defaults to "now".  So,
+        the NHL API sometimes uses the "now" string to default to the current date, but in some cases
+        such as preseaosn this is defaulting to last years season.  So, to get accurate teams for
+        this season, aka whatever year this is, you can supply the timestamp YYYY-MM-DD which should be the start
+        of the upcoming season.  For example, 2024-04-18 is for the season 2023-2025 and 2024-10-04 is for the season
+        2024-2025.
+
+        Returns a list of dicts with all the teams info.
+        Updated in 2.10.0, this pulls from current standings API, aggregates a list of teams
+        and their conf/div, joins it with franchise ID, and returns it.  This isnt pretty but
+        the NHL API has limitations to return this data in 1 request.
         :return: dict
         """
-        data_resource = importlib.resources.files("nhlpy") / "data"
-        teams_info = json.loads((data_resource / "teams_20232024.json").read_text())["teams"]
+        teams_info = self.client.get_by_url(full_resource=f"https://api-web.nhle.com/v1/standings/{date}").json()[
+            "standings"
+        ]
+        teams = []
+        for i in teams_info:
+            team = {
+                "conference": {"abbr": i["conferenceAbbrev"], "name": i["conferenceName"]},
+                "division": {"abbr": i["divisionAbbrev"], "name": i["divisionName"]},
+                "name": i["teamName"]["default"],
+                "common_name": i["teamCommonName"]["default"],
+                "abbr": i["teamAbbrev"]["default"],
+                "logo": i["teamLogo"],
+            }
+            teams.append(team)
 
         # We also need to get "franchise_id", which is different than team_id.  This is used in the stats.
         franchises = self.all_franchises()
         for f in franchises:
-            for team in teams_info:
+            for team in teams:
                 if "Canadiens" in f["fullName"] and "Canadiens" in team["name"]:
                     team["franchise_id"] = f["id"]
                     continue
@@ -30,7 +51,7 @@ class Teams:
                 if f["fullName"] == team["name"]:
                     team["franchise_id"] = f["id"]
 
-        return teams_info
+        return teams
 
     def roster(self, team_abbr: str, season: str) -> dict:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nhl-api-py"
-version = "2.9.2"
+version = "2.10.0"
 description = "NHL API (Updated for 2024/2025) and EDGE Stats.  For standings, team stats, outcomes, player information.  Contains each individual API endpoint as well as convience methods as well as pythonic query builder for more indepth EDGE stats."
 authors = ["Corey Schaf <cschaf@gmail.com>"]
 readme = "README.md"

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -6,8 +6,3 @@ def test_roster(h_m, nhl_client):
     nhl_client.teams.roster(team_abbr="BUF", season="20202021")
     h_m.assert_called_once()
     assert h_m.call_args[1]["url"] == "https://api-web.nhle.com/v1/roster/BUF/20202021"
-
-
-def test_teams_info(nhl_client):
-    teams = nhl_client.teams.teams_info()
-    assert len(teams) == 33


### PR DESCRIPTION
- This endpoint no longer returns hardcoded information.  It now uses a bit of a hack, calling standings, to get all team information, conf and division information.  It then joins this with francise info to get the franchcise_id required for stats endpoints.  This does change the func return type so it is a bit of a breaking change.  This also takes in a date param, to get previous season teams, which is helpful bc for some reason they keep adding and changing teams in this league every year.