### PR TITLE
Schedule API Adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,12 @@ client.stats.goalie_stats_summary_simple(start_season="20242025", stats_type="su
 ## Schedule Endpoints
 
 ```python
+
+# Returns the games for the given date.
 client.schedule.get_schedule(date="2021-01-13")
-client.schedule.get_schedule()
+
+# Return games for the week of (date)
+client.schedule.get_weekly_schedule(date="2021-01-13")
 
 client.schedule.get_schedule_by_team_by_month(team_abbr="BUF")
 client.schedule.get_schedule_by_team_by_month(team_abbr="BUF", month="2021-01")

--- a/nhlpy/_version.py
+++ b/nhlpy/_version.py
@@ -1,3 +1,3 @@
 # Should this be driven by the main pyproject.toml file? yes, is it super convoluted? yes, can it wait? sure
 
-__version__ = "2.10.2"
+__version__ = "2.11.0"

--- a/nhlpy/api/schedule.py
+++ b/nhlpy/api/schedule.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional, List
 
 from nhlpy.http_client import HttpClient
@@ -7,10 +8,39 @@ class Schedule:
     def __init__(self, http_client: HttpClient) -> None:
         self.client = http_client
 
-    def get_schedule(self, date: Optional[str] = None) -> dict:
+    def get_schedule(self, date: str = None) -> dict:
         """
-        Get the schedule for the NHL for the given date.  If no date is supplied it will
-        default to today.
+        Get the schedule for the NHL for the given date.  Contains only games for the given date.
+        :param date:  In format YYYY-MM-DD.
+        :return: dict
+        """
+        try:
+            # Parse and reformat the date to ensure YYYY-MM-DD
+            date = datetime.strptime(date, "%Y-%m-%d").strftime("%Y-%m-%d")
+        except ValueError:
+            raise ValueError("Invalid date format. Please use YYYY-MM-DD.")
+
+        schedule_data: dict = self.client.get(resource=f"schedule/{date}").json()
+        response_payload = {
+            "nextStartDate": schedule_data["nextStartDate"],
+            "previousStartDate": schedule_data["previousStartDate"],
+            "date": date,
+        }
+
+        matching_day = next((day for day in schedule_data["gameWeek"] if day["date"] == date), None)
+
+        if matching_day:
+            response_payload["games"] = matching_day["games"]
+            response_payload["numberOfGames"] = len(matching_day["games"])
+
+        return response_payload
+
+    def get_weekly_schedule(self, date: Optional[str] = None) -> dict:
+        """
+        Get the schedule for the NHL for the week of `date`.  If no date is supplied it will
+        default to today. What the "NHL" deems as "today" seems to switch over around 12 est.  Its preferred you
+        supply a date
+
         :param date:  In format YYYY-MM-DD.  If no date is supplied, it will default to "Today".  Which in case
             of the NHL could be today or yesterday depending on how early you call it.
         :return: dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nhl-api-py"
-version = "2.10.2"
+version = "2.11.0"
 description = "NHL API (Updated for 2024/2025) and EDGE Stats.  For standings, team stats, outcomes, player information.  Contains each individual API endpoint as well as convience methods as well as pythonic query builder for more indepth EDGE stats."
 authors = ["Corey Schaf <cschaf@gmail.com>"]
 readme = "README.md"

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 
 @mock.patch("httpx.Client.get")
 def test_get_schedule_with_date(h_m, nhl_client):
@@ -9,8 +11,28 @@ def test_get_schedule_with_date(h_m, nhl_client):
 
 
 @mock.patch("httpx.Client.get")
-def test_get_schedule_with_no_date(h_m, nhl_client):
-    nhl_client.schedule.get_schedule()
+def test_get_schedule_with_fixable_date(h_m, nhl_client):
+    nhl_client.schedule.get_schedule("2024-10-9")
+    h_m.assert_called_once()
+    assert h_m.call_args[1]["url"] == "https://api-web.nhle.com/v1/schedule/2024-10-09"
+
+
+@mock.patch("httpx.Client.get")
+def test_get_schedule_will_error_with_bad_date(h_m, nhl_client):
+    with pytest.raises(ValueError):
+        nhl_client.schedule.get_schedule("2024-10-09-")
+
+
+@mock.patch("httpx.Client.get")
+def test_get_weekly_schedule_with_date(h_m, nhl_client):
+    nhl_client.schedule.get_weekly_schedule(date="2021-01-01")
+    h_m.assert_called_once()
+    assert h_m.call_args[1]["url"] == "https://api-web.nhle.com/v1/schedule/2021-01-01"
+
+
+@mock.patch("httpx.Client.get")
+def test_get_weekly_schedule_with_no_date(h_m, nhl_client):
+    nhl_client.schedule.get_weekly_schedule()
     h_m.assert_called_once()
     assert h_m.call_args[1]["url"] == "https://api-web.nhle.com/v1/schedule/now"
 


### PR DESCRIPTION
Schedule API: schedule.py
- get_schedule(date) no longer has an optional parameter 'date'.  This is now a required parameter.  This method now will reduce down the response payload to only the games for the supplied date.  This is a change from the old way.  Old functionality has been moved to 'get_weekly_schedule'
- get_weekly_schedule(date?) has been added to return the weekly games, for the week of the supplied date.  Data is still optional but defaults to the NHL interrepation of 'now' or 'today'.

- Adds new tests to cover functionality in these updated schedule endpoints

closes #70 