### PR TITLE
Bug Fix: Double URL Encoding in Stats APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,3 +373,27 @@ $ ruff .
 $ black .
 
 ```
+
+
+#### Poetry version management
+```
+# View current version
+poetry version
+
+# Bump version
+poetry version patch  # 0.1.0 -> 0.1.1
+poetry version minor  # 0.1.0 -> 0.2.0
+poetry version major  # 0.1.0 -> 1.0.0
+
+# Set specific version
+poetry version 2.0.0
+
+# Set pre-release versions
+poetry version prepatch  # 0.1.0 -> 0.1.1-alpha.0
+poetry version preminor  # 0.1.0 -> 0.2.0-alpha.0
+poetry version premajor  # 0.1.0 -> 1.0.0-alpha.0
+
+# Specify pre-release identifier
+poetry version prerelease  # 0.1.0 -> 0.1.0-alpha.0
+poetry version prerelease beta  # 0.1.0-alpha.0 -> 0.1.0-beta.0
+```

--- a/nhlpy/_version.py
+++ b/nhlpy/_version.py
@@ -1,3 +1,0 @@
-# Should this be driven by the main pyproject.toml file? yes, is it super convoluted? yes, can it wait? sure
-
-__version__ = "2.11.0"

--- a/nhlpy/api/stats.py
+++ b/nhlpy/api/stats.py
@@ -245,7 +245,7 @@ class Stats:
             penaltykill, penaltyShots, powerplay, puckPossessions, summaryshooting, percentages, scoringRates,
             scoringpergame, shootout, shottype, timeonice
         :param query_context:
-        :param aggregate: bool - If doing multiple years, you can choose to aggreate the date per player,
+        :param aggregate: bool - If doing multiple years, you can choose to aggregate the date per player,
             or have separate entries for each one.
         :param sort_expr: A list of key/value pairs for sort criteria.  As used in skater_stats_summary(), this is
             in the format:
@@ -269,7 +269,7 @@ class Stats:
         if not sort_expr:
             sort_expr = SortingOptions.get_default_sorting_for_report(report_type)
 
-        q_params["sort"] = urllib.parse.quote(json.dumps(sort_expr))
+        q_params["sort"] = json.dumps(sort_expr)
         q_params["cayenneExp"] = query_context.query_str
         return self.client.get_by_url(
             f"https://api.nhle.com/stats/rest/en/skater/{report_type}", query_params=q_params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "nhl-api-py"
-version = "2.11.0"
+version = "2.11.1"
 description = "NHL API (Updated for 2024/2025) and EDGE Stats.  For standings, team stats, outcomes, player information.  Contains each individual API endpoint as well as convience methods as well as pythonic query builder for more indepth EDGE stats."
 authors = ["Corey Schaf <cschaf@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
- When using the stats + query builder in a notebook env, there was some double url encoding happening which was breaking the request.
- Removes __version.py file, as it not needed