### PR TITLE
Add support for the wsc/game-story API endpoint

### DIFF
--- a/nhlpy/api/game_center.py
+++ b/nhlpy/api/game_center.py
@@ -68,3 +68,11 @@ class GameCenter:
         :return: dict
         """
         return self.client.get(resource=f"gamecenter/{game_id}/right-rail").json()
+
+    def game_story(self, game_id: str) -> dict:
+        """
+        Get game story information for the game id. GameIds can be retrieved from the schedule endpoint.
+        :param game_id: The game_id for the game you want the game story for.
+        :return: dict
+        """
+        return self.client.get(resource=f"wsc/game-story/{game_id}").json()


### PR DESCRIPTION
The calls and details I found via https://github.com/Zmalski/NHL-API-Reference?tab=readme-ov-file#get-game-story

Essentially this API is the new API found game end stats such as overall PP, PK, FaceOff Win percentage, blocked shots, etc. This was originally part of the summary section of the boxscore but looks like for this season, gamecenter/summary is now an empty dict and all that info has been moved to this new API.